### PR TITLE
Tests HSTS

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,8 +142,8 @@
 <div class="test cors cors_redirect_hsts">
   <strong>Test:</strong> CORS GET request for HTTP->HTTPS asset redirect (Strict Transport).
   <code>
-    <a href="http://cdn.konklone.io/js/cors_redirect_hsts.js">
-      http://cdn.konklone.io/js/cors_redirect_hsts.js
+    <a href="http://www.cdn.konklone.io/js/cors_redirect_hsts.js">
+      http://www.cdn.konklone.io/js/cors_redirect_hsts.js
     </a>
   </code>
 </div>
@@ -164,7 +164,7 @@
   $.getScript("http://cdn.konklone.io/js/script_redirect.js" + cachebuster);
 
   // test: <script> loading of .js on HTTP->HTTPS redirect (HSTS)
-  $.getScript("http://cdn.konklone.io/js/script_redirect_hsts.js" + cachebuster);
+  $.getScript("http://www.cdn.konklone.io/js/script_redirect_hsts.js" + cachebuster);
 
 
   if (window._cors) {
@@ -178,7 +178,7 @@
     $.get("http://cdn.konklone.io/js/cors_redirect.js" + cachebuster);
 
     // test: CORS on HTTP->HTTPS redirect (HSTS)
-    $.get("http://cdn.konklone.io/js/cors_redirect_hsts.js" + cachebuster);
+    $.get("http://www.cdn.konklone.io/js/cors_redirect_hsts.js" + cachebuster);
   }
 
   // after 10s, if the tests aren't successes, deem them failures

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
 <ul>
   <li><code>plain-cdn.konklone.io</code> serves only HTTP.</li>
   <li><code>cdn.konklone.io</code> redirects HTTP to HTTPS (no Strict Transport).</li>
+  <li><code>www.cdn.konklone.io</code> redirects HTTP to HTTPS (Strict Transport, so make sure to run test at least twice).
   <li>Fetched resources are not cached.</li>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -103,6 +103,15 @@
   </code>
 </div>
 
+<div class="test script_redirect_hsts">
+  <strong>Test:</strong> &lt;script&gt; tag for HTTP->HTTPS asset redirect (Strict Transport).
+  <code>
+    <a href="http://www.cdn.konklone.io/js/script_redirect_hsts.js">
+      http://www.cdn.konklone.io/js/script_redirect_hsts.js
+    </a>
+  </code>
+</div>
+
 <div class="test cors cors_control_https">
   <strong>Control:</strong> CORS GET request for HTTPS asset.
   <code>
@@ -130,6 +139,15 @@
   </code>
 </div>
 
+<div class="test cors cors_redirect_hsts">
+  <strong>Test:</strong> CORS GET request for HTTP->HTTPS asset redirect (Strict Transport).
+  <code>
+    <a href="http://cdn.konklone.io/js/cors_redirect_hsts.js">
+      http://cdn.konklone.io/js/cors_redirect_hsts.js
+    </a>
+  </code>
+</div>
+
 <script>
 
   var cachebuster = "?" + new Date().getTime().toString();
@@ -145,6 +163,9 @@
   // test: <script> loading of .js on HTTP->HTTPS redirect (no HSTS)
   $.getScript("http://cdn.konklone.io/js/script_redirect.js" + cachebuster);
 
+  // test: <script> loading of .js on HTTP->HTTPS redirect (HSTS)
+  $.getScript("http://cdn.konklone.io/js/script_redirect_hsts.js" + cachebuster);
+
 
   if (window._cors) {
     // control: CORS loading of HTTPS
@@ -153,8 +174,11 @@
     // control: CORS loading of HTTP
     $.get("http://plain-cdn.konklone.io/js/cors_control_http.js" + cachebuster);
 
-    // test: CORS on HTTP->HTTPS redirect
+    // test: CORS on HTTP->HTTPS redirect (no HSTS)
     $.get("http://cdn.konklone.io/js/cors_redirect.js" + cachebuster);
+
+    // test: CORS on HTTP->HTTPS redirect (HSTS)
+    $.get("http://cdn.konklone.io/js/cors_redirect_hsts.js" + cachebuster);
   }
 
   // after 10s, if the tests aren't successes, deem them failures

--- a/index.html
+++ b/index.html
@@ -184,8 +184,10 @@
   // after 10s, if the tests aren't successes, deem them failures
   setTimeout(function() {
     var names = [
-      'script_control_https', 'script_control_http', 'script_redirect',
-      'cors_control_https',   'cors_control_http',   'cors_redirect'
+      'script_control_https', 'script_control_http',
+      'script_redirect', 'script_redirect_hsts',
+      'cors_control_https', 'cors_control_http',
+      'cors_redirect', 'cors_redirect_hsts'
     ];
     for (var i=0; i<names.length; i++)
       if (!loaded[names[i]]) failed(names[i]);

--- a/js/cors_redirect_hsts.js
+++ b/js/cors_redirect_hsts.js
@@ -1,7 +1,7 @@
 
 /**
   Meant to be accessed via CORS at:
-  http://cdn.konklone.io/cors_redirect_hsts.js
+  http://www.cdn.konklone.io/cors_redirect_hsts.js
 
   This should load over a 301 redirect from HTTP to HTTPS.
   (*With* Strict Transport.)

--- a/js/cors_redirect_hsts.js
+++ b/js/cors_redirect_hsts.js
@@ -1,0 +1,13 @@
+
+/**
+  Meant to be accessed via CORS at:
+  http://cdn.konklone.io/cors_redirect_hsts.js
+
+  This should load over a 301 redirect from HTTP to HTTPS.
+  (*With* Strict Transport.)
+
+  Used to pass the test at:
+  http://konklone.io/cdns-to-https/
+**/
+
+done('cors_redirect_hsts');

--- a/js/script_redirect_hsts.js
+++ b/js/script_redirect_hsts.js
@@ -1,7 +1,7 @@
 
 /**
   Meant to be accessed via <script> at:
-  http://cdn.konklone.io/script_redirect_hsts.js
+  http://www.cdn.konklone.io/script_redirect_hsts.js
 
   This should load over a 301 redirect from HTTP to HTTPS.
   (*With* Strict Transport.)

--- a/js/script_redirect_hsts.js
+++ b/js/script_redirect_hsts.js
@@ -1,0 +1,13 @@
+
+/**
+  Meant to be accessed via <script> at:
+  http://cdn.konklone.io/script_redirect_hsts.js
+
+  This should load over a 301 redirect from HTTP to HTTPS.
+  (*With* Strict Transport.)
+
+  Used to pass the test at:
+  http://konklone.io/cdns-to-https/
+**/
+
+done('script_redirect_hsts');


### PR DESCRIPTION
This branch tests the effects of Strict Transport Security. The answer is: it doesn't affect things, either CORS or `<script>` requests.

I'm not including it in the main site, because the effect on programmatic tests is so strange - you need to run the tests twice to have them be at all different from the non-HSTS tests. I could submit the `www.cdn.konklone.io` domain to the preload list, but that seems a bit much, and will take many months to roll out besides (and will never be testable on older browsers that still support HSTS generally).

In any case, here's the full screenshot of them passing in Chrome stable on Linux (after many refreshes):

![hsts](https://cloud.githubusercontent.com/assets/4592/5997276/1b696396-aa87-11e4-80e1-bad7b2557b0a.png)

And here are the two network requests, internal redirects from `http://` to `https://`:

![screenshot from 2015-02-02 02 55 47](https://cloud.githubusercontent.com/assets/4592/5997284/267b4ad8-aa87-11e4-9c2c-ac13acd9bcdb.png)

![screenshot from 2015-02-02 02 56 06](https://cloud.githubusercontent.com/assets/4592/5997285/29d97740-aa87-11e4-9924-792d7b3cecf7.png)
