### PR TITLE
Automatically test behavior under Strict Transport Security

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,8 +134,8 @@
 <div class="test cors cors_hsts">
   <strong>Test:</strong> CORS GET request for HTTP->HTTPS asset under <a href="https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security">HTTP Strict Transport Security</a>.
   <code>
-    <a href="http://cdn.konklone.io/js/cors_hsts.js">
-      http://cdn.konklone.io/js/cors_hsts.js
+    <a href="http://www.cdn.konklone.io/js/cors_hsts.js">
+      http://www.cdn.konklone.io/js/cors_hsts.js
     </a>
   </code>
 </div>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
 <ul>
   <li><code>plain-cdn.konklone.io</code> serves only HTTP.</li>
   <li><code>cdn.konklone.io</code> redirects HTTP to HTTPS (no Strict Transport).</li>
+  <li><code>www.cdn.konklone.io</code> redirects HTTP to HTTPS (with Strict Transport set).</li>
   <li>Fetched resources are not cached.</li>
 </ul>
 
@@ -130,6 +131,15 @@
   </code>
 </div>
 
+<div class="test cors cors_hsts">
+  <strong>Test:</strong> CORS GET request for HTTP->HTTPS asset under <a href="https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security">HTTP Strict Transport Security</a>.
+  <code>
+    <a href="http://cdn.konklone.io/js/cors_hsts.js">
+      http://cdn.konklone.io/js/cors_hsts.js
+    </a>
+  </code>
+</div>
+
 <script>
 
   var cachebuster = "?" + new Date().getTime().toString();
@@ -155,13 +165,21 @@
 
     // test: CORS on HTTP->HTTPS redirect
     $.get("http://cdn.konklone.io/js/cors_redirect.js" + cachebuster);
+
+    // test: CORS with HSTS set
+    // this fetches an HTTPS version first, to guarantee that the header is seen. on return, it triggers a second function which then asks for the http:// version (and hopefully does an internal redirect and goes right for the https:// version).
+    function hsts_set() {
+      $.get("http://www.cdn.konklone.io/cors_hsts.js" + cachebuster);
+    }
+    $.get("https://www.cdn.konklone.io/cors_hsts_pre.js" + cachebuster);
   }
 
   // after 10s, if the tests aren't successes, deem them failures
   setTimeout(function() {
     var names = [
       'script_control_https', 'script_control_http', 'script_redirect',
-      'cors_control_https',   'cors_control_http',   'cors_redirect'
+      'cors_control_https',   'cors_control_http',   'cors_redirect',
+      'cors_hsts'
     ];
     for (var i=0; i<names.length; i++)
       if (!loaded[names[i]]) failed(names[i]);

--- a/index.html
+++ b/index.html
@@ -169,9 +169,9 @@
     // test: CORS with HSTS set
     // this fetches an HTTPS version first, to guarantee that the header is seen. on return, it triggers a second function which then asks for the http:// version (and hopefully does an internal redirect and goes right for the https:// version).
     function hsts_set() {
-      $.get("http://www.cdn.konklone.io/cors_hsts.js" + cachebuster);
+      $.get("http://www.cdn.konklone.io/js/cors_hsts.js" + cachebuster);
     }
-    $.get("https://www.cdn.konklone.io/cors_hsts_pre.js" + cachebuster);
+    $.get("https://www.cdn.konklone.io/js/cors_hsts_pre.js" + cachebuster);
   }
 
   // after 10s, if the tests aren't successes, deem them failures

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
 </div>
 
 <div class="test cors cors_hsts">
-  <strong>Test:</strong> CORS GET request for HTTP->HTTPS asset under <a href="https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security">HTTP Strict Transport Security</a>.
+  <strong>Test:</strong> CORS GET request for HTTP->HTTPS asset with <a href="https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security">HSTS</a>.
   <code>
     <a href="http://www.cdn.konklone.io/js/cors_hsts.js">
       http://www.cdn.konklone.io/js/cors_hsts.js

--- a/js/cors_hsts.js
+++ b/js/cors_hsts.js
@@ -1,0 +1,14 @@
+
+/**
+  Meant to be accessed via CORS at:
+  http://www.cdn.konklone.io/cors_hsts.js
+
+  By the time this runs, the browser should have witnessed
+  a securely-delivered HTTPS header for the domain, and do an
+  internal redirect first.
+
+  Used to pass the test at:
+  http://konklone.io/cdns-to-https/
+**/
+
+done('cors_hsts');

--- a/js/cors_hsts_pre.js
+++ b/js/cors_hsts_pre.js
@@ -1,0 +1,13 @@
+
+/**
+  Meant to be accessed via CORS at:
+  https://www.cdn.konklone.io/cors_hsts_pre.js
+
+  This should work without issue, and cause a HSTS-supporting
+  browser to remember the HSTS value for the next request.
+
+  Used to pass the test at:
+  http://konklone.io/cdns-to-https/
+**/
+
+hsts_set();

--- a/nginx/cdn.conf
+++ b/nginx/cdn.conf
@@ -44,12 +44,13 @@ server {
 
     include cdn.ssl.rules;
 
-    # only for www.cdn.konklone.io
-    add_header Strict-Transport-Security 'max-age=31536000';
 
     location / {
         root /home/cdn/cdn/;
         include cdn.cors;
+
+        # only for www.cdn.konklone.io
+        add_header Strict-Transport-Security 'max-age=31536000';
 
         access_log /home/cdn/cdn_access.log;
         error_log  /home/cdn/cdn_error.log;


### PR DESCRIPTION
![screenshot from 2015-02-08 17 43 57](https://cloud.githubusercontent.com/assets/4592/6098911/16c31fc0-afba-11e4-9566-7a7ca392b44e.png)

This adds an additional test for CORS requests, to see the effect of [Strict Transport Security](https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security) (HSTS).

Strict Transport is set only for the domain `www.cdn.konklone.io`. This test fires _two_ HTTP requests:
- One to `https://www.cdn.konklone.io/js/cors_hsts_pre.js` to ensure that the client has seen the Strict Transport header at least once, which should cause the browser to apply it from then on.
- When that finishes, it triggers a second CORS GET request to `http://www.cdn.konklone.io/js/cors_hsts.js`, which should perform an _internal_ redirect before fetching the HTTPS asset directly.

This works as expected in my testing on Chrome. I'm particularly interested to know whether this can address the CORS redirect issues seen in mobile Android (pre-4.4), iOS, and desktop Safari -- all of which support HSTS. 

If those browsers fail the normal CORS redirect, but can successfully fetch secure resources when it has an HSTS value set for that domain, that suggests that the [HSTS preload list](https://hstspreload.appspot.com/) could create a transition path that breaks fewer clients. Even Android pre-4.4 is likelier to update their version of Chrome than their whole OS.

Remaining questions:
- [x] Does this address the situation for any clients? (Test on BrowserStack once this is deployed.) **Update**: No :(
- [X] How effectively would the HSTS preload list ease breakage? Do mobile Chrome and iOS even use the HSTS preload list? What is the release and update cycle like for desktop Safari? **Update:** Moot :(
